### PR TITLE
DDCE-6058 - Removing scopes from API definition

### DIFF
--- a/app/v1/controllers/ApiDocumentationController.scala
+++ b/app/v1/controllers/ApiDocumentationController.scala
@@ -38,13 +38,6 @@ class ApiDocumentationController @Inject() (
     val apiDefinition = Json.parse(
       s"""
          |{
-         |  "scopes": [
-         |    {
-         |      "key": "read:register-nino",
-         |      "name": "Register NINO",
-         |      "description": "Register NINO"
-         |    }
-         |  ],
          |  "api": {
          |    "name": "Register NINO",
          |    "description": "Register NINO information for downstream service",

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -14,18 +14,6 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
 
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
@@ -34,13 +22,6 @@
         </encoder>
     </appender>
 
-    <logger name="accesslog" level="OFF" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="OFF"/>
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -28,13 +28,6 @@
     </appender>
 
 
-    <logger name="accesslog" level="WARN" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" level="WARN" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="WARN"/>
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -19,18 +19,6 @@
         <!--<encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>-->
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
 
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>

--- a/it/test/v1/endpoints/ApiDocumentationControllerISpec.scala
+++ b/it/test/v1/endpoints/ApiDocumentationControllerISpec.scala
@@ -54,13 +54,6 @@ class ApiDocumentationControllerISpec extends IntegrationBaseSpec {
       private val expectedJson: JsValue = Json.parse(
         """
           |{
-          |  "scopes": [
-          |    {
-          |      "key": "read:register-nino",
-          |      "name": "Register NINO",
-          |      "description": "Register NINO"
-          |    }
-          |  ],
           |  "api": {
           |    "name": "Register NINO",
           |    "description": "Register NINO information for downstream service",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.22.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.2")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.0.11")

--- a/test/v1/controllers/ApiDocumentationControllerSpec.scala
+++ b/test/v1/controllers/ApiDocumentationControllerSpec.scala
@@ -43,13 +43,6 @@ class ApiDocumentationControllerSpec extends ControllerBaseSpec with MockApiDefi
   private val expectedJson: JsValue = Json.parse(
     """
       |{
-      |  "scopes": [
-      |    {
-      |      "key": "read:register-nino",
-      |      "name": "Register NINO",
-      |      "description": "Register NINO"
-      |    }
-      |  ],
       |  "api": {
       |    "name": "Register NINO",
       |    "description": "Register NINO information for downstream service",


### PR DESCRIPTION
DDCE-6058 - Removing scopes from API definition